### PR TITLE
Fix README

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
Places `README.md` alongside `README` for nice HTML rendering on GitHub.  The `README` version is required for `./autogen.sh` 

http://stackoverflow.com/questions/8655937/github-readme-and-readme-md
http://www.sourceware.org/autobook/autobook/autobook_25.html

Fixes #2 
