### PR TITLE
fix linux build by using _Z_OF

### DIFF
--- a/third_party/zlib-1.2.3/contrib/minizip/ioapi.h
+++ b/third_party/zlib-1.2.3/contrib/minizip/ioapi.h
@@ -31,6 +31,11 @@
 #endif
 #endif
 
+#ifdef _Z_OF
+#undef OF
+#define OF _Z_OF
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Fixed build on Linux (gentoo, GCC). See this discussion: https://code.google.com/p/fritzing/issues/detail?id=1854
